### PR TITLE
Remove old local whisper code

### DIFF
--- a/AudioRecorder.py
+++ b/AudioRecorder.py
@@ -1,4 +1,4 @@
-import custom_speech_recognition as sr
+import speech_recognition as sr
 import pyaudiowpatch as pyaudio
 from datetime import datetime
 

--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -2,7 +2,7 @@ import wave
 import os
 import threading
 import tempfile
-import custom_speech_recognition as sr
+import speech_recognition as sr
 import io
 from datetime import timedelta, datetime, timezone
 import pyaudiowpatch as pyaudio

--- a/TranscriberModels.py
+++ b/TranscriberModels.py
@@ -1,43 +1,22 @@
-import torch
-from faster_whisper import WhisperModel
 from openai import OpenAI
-
-def get_model(use_api):
-    if use_api:
-        return APIWhisperTranscriber()
-    else:
-        return FasterWhisperTranscriber()
-
-class FasterWhisperTranscriber:
-    def __init__(self):
-        print(f"[INFO] Loading Faster Whisper model...")
-        self.model = WhisperModel("tiny.en", device="cuda" if torch.cuda.is_available() else "cpu", 
-                                 compute_type="float32" if torch.cuda.is_available() else "int8")
-        print(f"[INFO] Faster Whisper using GPU: {torch.cuda.is_available()}")
-
-    def get_transcription(self, wav_file_path, language="ru"):
-        try:
-            # language игнорируется для локальной модели
-            segments, _ = self.model.transcribe(wav_file_path, beam_size=5)
-            full_text = " ".join(segment.text for segment in segments)
-            return full_text.strip()
-        except Exception as e:
-            print(e)
-            return ''
 
 class APIWhisperTranscriber:
     def __init__(self, api_key=None):
         self.client = OpenAI(api_key=api_key)
-    
+
     def get_transcription(self, wav_file_path, language="ru"):
         try:
             with open(wav_file_path, "rb") as audio_file:
                 result = self.client.audio.transcriptions.create(
                     model="whisper-1",
                     file=audio_file,
-                    language=language
+                    language=language,
                 )
             return result.text.strip()
         except Exception as e:
             print(e)
             return ''
+
+
+def get_model(*_, **__):
+    return APIWhisperTranscriber()


### PR DESCRIPTION
## Summary
- clean up any imports of the deleted `custom_speech_recognition`
- drop the unused FasterWhisper model
- provide a thin wrapper around the Whisper API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6841d9c939c4832998352047d375717b