### PR TITLE
Fix transcript phrase handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def write_transcript(tb: ctk.CTkTextbox, items, start: int, end: int):
     inner.tag_configure("ctx_tag", background="#444444")
 
     spk_index = 0
-    for text, _, role in items:
+    for text, _, role, *_ in items:
         tag = "speaker_tag" if role == "Speaker" else "user_tag"
         extra = ()
         if role == "Speaker":


### PR DESCRIPTION
## Summary
- track phrase IDs for microphone and speaker streams
- preserve start timestamps when updating current phrase
- prevent transcript text loss across long pauses
- update transcript rendering for new tuple format

## Testing
- `python -m py_compile AudioTranscriber.py main.py gpt_manager.py`
- `python -m py_compile AudioRecorder.py TranscriberModels.py vertical_range_slider.py config_manager.py log_manager.py`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6849fd94190c83298986530e4b5afefa