### PR TITLE
Track transcripts by phrase id

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,8 @@ def write_transcript(tb: ctk.CTkTextbox, items, start: int, end: int):
     inner.tag_configure("ctx_tag", background="#444444")
 
     spk_index = 0
-    for text, _, role in items:
+    for item in items:
+        text, _, role = item[:3]
         tag = "speaker_tag" if role == "Speaker" else "user_tag"
         extra = ()
         if role == "Speaker":


### PR DESCRIPTION
## Summary
- keep a `phrase_id` for each speaker to avoid overwriting previous phrases
- update transcript logic to update by phrase id
- adjust transcript rendering to support new tuple layout

## Testing
- `python -m py_compile AudioTranscriber.py main.py`
- `pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a033faabc83299dda3d3689885093