### PR TITLE
Adjust recording timeout

### DIFF
--- a/AudioRecorder.py
+++ b/AudioRecorder.py
@@ -2,7 +2,8 @@ import custom_speech_recognition as sr
 import pyaudiowpatch as pyaudio
 from datetime import datetime
 
-RECORD_TIMEOUT = 3
+# Reduce the chunk length to lower latency during recording.
+RECORD_TIMEOUT = 0.8
 ENERGY_THRESHOLD = 1000
 DYNAMIC_ENERGY_THRESHOLD = False
 

--- a/AudioRecorder.py
+++ b/AudioRecorder.py
@@ -3,7 +3,9 @@ import pyaudiowpatch as pyaudio
 from datetime import datetime
 
 # Reduce the chunk length to lower latency during recording.
-RECORD_TIMEOUT = 0.8
+# Using one second chunks keeps speech from getting cut off
+# while still maintaining responsiveness.
+RECORD_TIMEOUT = 1.0
 ENERGY_THRESHOLD = 1000
 DYNAMIC_ENERGY_THRESHOLD = False
 

--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -9,7 +9,8 @@ from datetime import timedelta, datetime, timezone
 import pyaudiowpatch as pyaudio
 from heapq import merge
 
-PHRASE_TIMEOUT = 3.05
+# Slightly longer than RECORD_TIMEOUT for correct phrase segmentation.
+PHRASE_TIMEOUT = 0.85
 MAX_PHRASES = 10
 
 class AudioTranscriber:

--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -10,7 +10,8 @@ import pyaudiowpatch as pyaudio
 from heapq import merge
 
 # Slightly longer than RECORD_TIMEOUT for correct phrase segmentation.
-PHRASE_TIMEOUT = 0.85
+# Keep a small margin so phrases merge naturally.
+PHRASE_TIMEOUT = 1.05
 MAX_PHRASES = 10
 
 class AudioTranscriber:


### PR DESCRIPTION
## Summary
- lower `RECORD_TIMEOUT` to shorten recording chunks
- decrease `PHRASE_TIMEOUT` for matching phrase segmentation

## Testing
- `python3 -m py_compile AudioRecorder.py AudioTranscriber.py`
- `find . -name '*.py' | xargs python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_684a06522c3c8329beeb78199bd2e4db