### PR TITLE
Add async phrase buffering for transcription

### DIFF
--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -79,7 +79,6 @@ class AudioTranscriber:
         pending_tasks = set()
 
         while True:
-            now = datetime.utcnow()
 
             while True:
                 try:
@@ -104,6 +103,8 @@ class AudioTranscriber:
                         ))
                 except queue.Empty:
                     break
+
+            now = datetime.utcnow()
 
             for who in ("You", "Speaker"):
                 src = self.audio_sources[who]
@@ -153,7 +154,8 @@ class AudioTranscriber:
             source_info["new_phrase"] = False
 
         source_info["phrase_buffer"] += data
-        source_info["last_sample"] = bytes(source_info["phrase_buffer"])
+        # keep last_sample for backward compatibility but avoid expensive copy
+        source_info["last_sample"] = source_info["phrase_buffer"]
         source_info["last_spoken"] = time_spoken
 
         return completed


### PR DESCRIPTION
## Summary
- buffer audio chunks per speaker and send once after phrase timeout
- process transcription in background tasks so queue consumption never blocks

## Testing
- `python -m py_compile AudioTranscriber.py`
- `python -m py_compile AudioRecorder.py TranscriberModels.py gpt_manager.py config_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684a09a28e5c83298a212f3c18eb3c04